### PR TITLE
Deriving java version from release list (issue #18)

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -42,22 +42,17 @@ tar_strip_level() {
 }
 
 get_variant() {
-  local version="$1"
   case "$(uname -s)" in
     Linux)
       case "$(uname -m)" in
         x86_64) echo linux-amd64 ;;
+        arm64) echo linux-aarch64 ;;
         *) fail "$(uname -m) is not supported on linux" ;;
       esac ;;
     Darwin)
       case "$(uname -m)" in
-        x86_64)
-          if version_is_one $version; then
-            echo macos-amd64
-          else
-            echo darwin-amd64
-          fi
-          ;;
+        x86_64) echo darwin-amd64 ;;
+        arm64) echo darwin-aarch64 ;;
         *) fail "$(uname -m) is not supported on macos" ;;
       esac ;;
     *) fail "$(uname -s) is not supported" ;;
@@ -81,29 +76,12 @@ downloaded_file_path() {
   echo "$tmp_download_dir/$pkg_name"
 }
 
-version_is_one() {
-  local version=$1
-  local major_version=$(echo $version | cut -d'.' -f 1)
-  test "$major_version" -eq 1 
-}
-
-version_is_ce_build() {
-  local version=$1
-  echo "$version" | grep -q -E "^.*-java[0-9]+$"
-}
-
 download_url() {
   local version=$1
-  local variant=$(get_variant $version)
-  if version_is_ce_build $version; then
-    local graalvm_version=$(echo $version | cut -f1 -d-)
-    local java_version=$(echo $version | cut -f2 -d-)
-    echo "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${graalvm_version}/graalvm-ce-${java_version}-${variant}-${graalvm_version}.tar.gz"
-  elif version_is_one $version; then
-    echo "https://github.com/oracle/graal/releases/download/vm-${version}/graalvm-ce-${version}-${variant}.tar.gz"
-  else
-    echo "https://github.com/oracle/graal/releases/download/vm-${version}/graalvm-ce-${variant}-${version}.tar.gz"
-  fi
+  local variant=$(get_variant)
+  local graalvm_version=$(echo $version | cut -f1 -d-)
+  local java_version=$(echo $version | cut -f2 -d-)
+  echo "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${graalvm_version}/graalvm-ce-${java_version}-${variant}-${graalvm_version}.tar.gz"
 }
 
 installer $ASDF_INSTALL_TYPE $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH

--- a/bin/list-all
+++ b/bin/list-all
@@ -4,7 +4,24 @@ if [ -n "$GITHUB_API_TOKEN" ]; then
  cmd="$cmd -H 'Authorization: token $GITHUB_API_TOKEN'"
 fi
 
+get_variant() {
+  case "$(uname -s)" in
+    Linux)
+      case "$(uname -m)" in
+        x86_64) echo linux-amd64 ;;
+        arm64) echo linux-aarch64 ;;
+        *) fail "$(uname -m) is not supported on linux" ;;
+      esac ;;
+    Darwin)
+      case "$(uname -m)" in
+        x86_64) echo darwin-amd64 ;;
+        arm64) echo darwin-aarch64 ;;
+        *) fail "$(uname -m) is not supported on macos" ;;
+      esac ;;
+    *) fail "$(uname -s) is not supported" ;;
+  esac
+}
+
 (
-  $cmd 'https:///api.github.com/repos/oracle/graal/releases' | jq -r 'sort_by(.created_at) | .[] | select (.prerelease == false) | select (.tag_name | contains("vm-")) | select (.assets | length > 0) | .tag_name | ltrimstr("vm-")'
-  $cmd 'https:///api.github.com/repos/graalvm/graalvm-ce-builds/releases' | jq -r 'sort_by(.created_at) | .[] | . + {"java": ["java8", "java11"]} | select (.prerelease == false) | select (.tag_name | contains("vm-")) | select (.assets | length > 0) | .tag_name + "-" + .java[]| ltrimstr("vm-")'
+  $cmd 'https:///api.github.com/repos/graalvm/graalvm-ce-builds/releases' | jq -r "sort_by(.created_at) | .[] | select(.prerelease==false) | .assets[].name | capture(\"^graalvm-ce-(?<java>java[0-9]+)-$(get_variant)-(?<version>[0-9\\\.]+)\\\.tar\\\.gz$\") | [.version,.java] | join(\"-\")"
 ) | xargs echo


### PR DESCRIPTION
Issue #18 calls out that Java 16 and higher isn't supported by the `$ asdf list-all graalvm` command, and in fact that command returns entries which are not currently available (i.e. 22.1.0-java8).  This update should provide a list of the graalvm releases that are available, along with the OpenJDK versions that are supported by them.

In addition to supporting Java 16+, this also addresses an issue where the `list all` command would return items which weren't available for the architecture of the current machine (i.e. Apple Silicon).  This addresses that as well.