### PR TITLE
fix: update releases URL

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -5,6 +5,6 @@ if [ -n "$GITHUB_API_TOKEN" ]; then
 fi
 
 (
-  $cmd 'https:///api.github.com/repos/oracle/graal/releases' | jq -r 'sort_by(.created_at) | .[] | select (.prerelease == false) | select (.tag_name | contains("vm-")) | select (.assets | length > 0) | .tag_name | ltrimstr("vm-")'
-  $cmd 'https:///api.github.com/repos/graalvm/graalvm-ce-builds/releases' | jq -r 'sort_by(.created_at) | .[] | . + {"java": ["java8", "java11"]} | select (.prerelease == false) | select (.tag_name | contains("vm-")) | select (.assets | length > 0) | .tag_name + "-" + .java[]| ltrimstr("vm-")'
+  $cmd 'https:///api.github.com/repos/graalvm/graalvm-ce-builds/releases' | jq -r 'sort_by(.created_at) | .[] | select (.prerelease == false) | select (.tag_name | contains("vm-")) | select (.assets | length > 0) | .tag_name | ltrimstr("vm-")'
+  $cmd 'https:///api.github.com/repos/graalvm/graalvm-ce-builds/releases' | jq -r 'sort_by(.created_at) | .[] | . + {"java": ["java11", "java17", "java19"]} | select (.prerelease == false) | select (.tag_name | contains("vm-")) | select (.assets | length > 0) | .tag_name + "-" + .java[]| ltrimstr("vm-")' | sort
 ) | xargs echo


### PR DESCRIPTION
As seen on https://github.com/oracle/graal/releases/tag/vm-19.3.1 the releases URL has moved.

This fix updates the URL and also the supported Java versions for which there are GraalVM releases available. Fixes #21 

Also, release names are now sorted in the output. Fixes #19 